### PR TITLE
 fix: Bug #58523 - Add suitable startup probe for LDAP secondary servers

### DIFF
--- a/helm/ldap-server/templates/deployment-proxy.yaml
+++ b/helm/ldap-server/templates/deployment-proxy.yaml
@@ -202,6 +202,8 @@ spec:
           lifecycle: {{- include "common.tplvalues.render" (dict "value" .Values.lifecycleHooks "context" .) | nindent 12 }}
           {{- end }}
           volumeMounts:
+            - name: tmp-volume
+              mountPath: /tmp
             - name: usr-share-univention-ldap-volume
               mountPath: /usr/share/univention-ldap
             - name: usr-share-oidc-volume
@@ -251,6 +253,8 @@ spec:
             {{- include "common.tplvalues.render" (dict "value" .Values.extraVolumeMounts "context" .) | nindent 12 }}
             {{- end }}
       volumes:
+        - name: tmp-volume
+          emptyDir: {}
         - name: "data-volume"
           emptyDir: {}
         - name: "var-run-volume"

--- a/helm/ldap-server/templates/statefulset-primary.yaml
+++ b/helm/ldap-server/templates/statefulset-primary.yaml
@@ -369,11 +369,15 @@ spec:
           readinessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.readinessProbe "context" .) | nindent 12 }}
           startupProbe: {{- include "common.tplvalues.render" (dict "value" .Values.startupProbe "context" .) | nindent 12 }}
           volumeMounts:
+            - name: tmp-volume
+              mountPath: /tmp
             {{- if .Values.persistence.enabled }}
             - name: "shared-data"
               mountPath: /var/lib/univention-ldap
             {{- end }}
       volumes:
+        - name: tmp-volume
+          emptyDir: {}
         - name: "slapd-overlay-unix-socket-volume"
           emptyDir: {}
         - name: "usr-share-univention-ldap-volume"

--- a/helm/ldap-server/templates/statefulset-secondary.yaml
+++ b/helm/ldap-server/templates/statefulset-secondary.yaml
@@ -254,7 +254,7 @@ spec:
           {{- end }}
           livenessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.livenessProbe "context" .) | nindent 12 }}
           readinessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.readinessProbe "context" .) | nindent 12 }}
-          startupProbe: {{- include "common.tplvalues.render" (dict "value" .Values.startupProbe "context" .) | nindent 12 }}
+          startupProbe: {{- include "common.tplvalues.render" (dict "value" (coalesce .Values.startupProbeSecondary .Values.startupProbe) "context" .) | nindent 12 }}
           ports:
             {{- range $key, $value := .Values.service.ports }}
             - name: {{ $key }}

--- a/helm/ldap-server/templates/statefulset-secondary.yaml
+++ b/helm/ldap-server/templates/statefulset-secondary.yaml
@@ -266,6 +266,8 @@ spec:
           lifecycle: {{- include "common.tplvalues.render" (dict "value" .Values.lifecycleHooks "context" .) | nindent 12 }}
           {{- end }}
           volumeMounts:
+            - name: tmp-volume
+              mountPath: /tmp
             - name: usr-share-univention-ldap-volume
               mountPath: /usr/share/univention-ldap
             - name: usr-share-oidc-volume
@@ -331,6 +333,8 @@ spec:
             {{- include "common.tplvalues.render" (dict "value" .Values.extraVolumeMounts "context" .) | nindent 12 }}
             {{- end }}
       volumes:
+        - name: tmp-volume
+          emptyDir: {}
         - name: "usr-share-univention-ldap-volume"
           emptyDir: {}
         - name: "usr-share-saml-volume"

--- a/helm/ldap-server/values.yaml
+++ b/helm/ldap-server/values.yaml
@@ -366,6 +366,28 @@ startupProbe:
   tcpSocket:
     port: 389
 
+#  Configure extra options for containers probes for secondary servers.
+# This startup probe checks that LDAP is responding and can serve queries,
+# ensuring the secondary has completed initial replication before it receives traffic.
+# The probe queries the base DN to verify the server has data and is ready.
+startupProbeSecondary:
+  # -- Delay after container start until StartupProbe is executed.
+  initialDelaySeconds: 15
+  # -- Number of failed executions until container is terminated.
+  # Increased to 30 to allow time for initial replication to complete.
+  failureThreshold: 30
+  # -- Time between probe executions.
+  periodSeconds: 10
+  # -- Number of successful executions after failed ones until container is marked healthy.
+  successThreshold: 1
+  # -- Timeout for command return.
+  timeoutSeconds: 5
+  exec:
+    command:
+      - "/bin/sh"
+      - "-c"
+      - 'ldapsearch -H ldapi:/// -Y EXTERNAL -b "${LDAP_BASEDN}" -s base "(objectClass=*)" dn >/dev/null 2>&1'
+
 # -- Allows to configure the system extensions to load. This is intended for
 # internal usage, prefer to use `extensions` for user configured extensions.
 # This value will override the configuration in `global.systemExtensions`.


### PR DESCRIPTION
**Problem**

Secondary LDAP servers were using a tcp based startup probe that only checked if port 389 was listening, not if replication had completed. This could cause secondary servers to receive traffic before replication data was available, leading to errors when clients queried data that hadn't been replicated yet.

**Solution**

    Added startupProbeSecondary configuration with exec-based probe
    Probe queries base DN to verify ldap is responding and data is accessible
    Updated statefulset-secondary.yaml to use startupProbeSecondary with coalesce fallback to default startupProbe
    Increased failureThreshold to 30 to allow sufficient time for initial replication to complete

**Changes**

    helm/ldap-server/values.yaml: Added startupProbeSecondary configuration with exec command that queries base DN
    helm/ldap-server/templates/statefulset-secondary.yaml: Updated startupProbe to use startupProbeSecondary if defined, otherwise fallback to default

**Testing**

    Verified Helm template renders correctly with exec command for secondary servers
    Confirmed primary servers still use default tcpSocket probe (unchanged)
    Pattern matches existing readinessProbePrimary exec-based probe approach

**Related**

    Bug #58523
