### PR TITLE
Fix bug 58707: Mount emptyDir volume to /tmp for writable tempfiles

### DIFF
--- a/helm/ldap-server/templates/deployment-proxy.yaml
+++ b/helm/ldap-server/templates/deployment-proxy.yaml
@@ -202,6 +202,8 @@ spec:
           lifecycle: {{- include "common.tplvalues.render" (dict "value" .Values.lifecycleHooks "context" .) | nindent 12 }}
           {{- end }}
           volumeMounts:
+            - name: tmp-volume
+              mountPath: /tmp
             - name: usr-share-univention-ldap-volume
               mountPath: /usr/share/univention-ldap
             - name: usr-share-oidc-volume
@@ -237,6 +239,8 @@ spec:
             - name: "config-map-ucr"
               mountPath: "/etc/univention/base-defaults.conf"
               subPath: "base-defaults.conf"
+            - name: tmp-volume
+              mountPath: /tmp
             - name: "data-volume"
               mountPath: /var/lib/univention-ldap
             {{- if .Values.ldapServer.tls.enabled }}
@@ -251,6 +255,8 @@ spec:
             {{- include "common.tplvalues.render" (dict "value" .Values.extraVolumeMounts "context" .) | nindent 12 }}
             {{- end }}
       volumes:
+        - name: tmp-volume
+          emptyDir: {}
         - name: "data-volume"
           emptyDir: {}
         - name: "var-run-volume"

--- a/helm/ldap-server/templates/statefulset-primary.yaml
+++ b/helm/ldap-server/templates/statefulset-primary.yaml
@@ -369,11 +369,15 @@ spec:
           readinessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.readinessProbe "context" .) | nindent 12 }}
           startupProbe: {{- include "common.tplvalues.render" (dict "value" .Values.startupProbe "context" .) | nindent 12 }}
           volumeMounts:
+            - name: tmp-volume
+              mountPath: /tmp
             {{- if .Values.persistence.enabled }}
             - name: "shared-data"
               mountPath: /var/lib/univention-ldap
             {{- end }}
       volumes:
+        - name: tmp-volume
+          emptyDir: {}
         - name: "slapd-overlay-unix-socket-volume"
           emptyDir: {}
         - name: "usr-share-univention-ldap-volume"

--- a/helm/ldap-server/templates/statefulset-secondary.yaml
+++ b/helm/ldap-server/templates/statefulset-secondary.yaml
@@ -266,6 +266,8 @@ spec:
           lifecycle: {{- include "common.tplvalues.render" (dict "value" .Values.lifecycleHooks "context" .) | nindent 12 }}
           {{- end }}
           volumeMounts:
+            - name: tmp-volume
+              mountPath: /tmp
             - name: usr-share-univention-ldap-volume
               mountPath: /usr/share/univention-ldap
             - name: usr-share-oidc-volume
@@ -331,6 +333,8 @@ spec:
             {{- include "common.tplvalues.render" (dict "value" .Values.extraVolumeMounts "context" .) | nindent 12 }}
             {{- end }}
       volumes:
+        - name: tmp-volume
+          emptyDir: {}
         - name: "usr-share-univention-ldap-volume"
           emptyDir: {}
         - name: "usr-share-saml-volume"


### PR DESCRIPTION
## Problem

`univention-ldapsearch` fails in Kubernetes pods with read-only root filesystems because it cannot create temporary files in `/tmp`. The script uses `mktemp` to create temporary files, but when the root filesystem is read-only (common in Kubernetes security contexts), `/tmp` is also read-only, causing the script to fail with errors like "cannot create tempfile".

## Solution

This fix mounts an `emptyDir` volume to `/tmp` in all LDAP server deployments (primary, secondary, and proxy). This follows the standard Kubernetes pattern for handling temporary files in read-only container environments. The `emptyDir` volume provides a writable temporary directory that persists for the pod's lifetime.

## Changes

- Added `tmp-volume` emptyDir mount to `/tmp` in `statefulset-primary.yaml`
- Added `tmp-volume` emptyDir mount to `/tmp` in `statefulset-secondary.yaml`
- Added `tmp-volume` emptyDir mount to `/tmp` in `deployment-proxy.yaml`

## Testing

- Verified templates render correctly with the tmp-volume mount
- Tested container environment with read-only rootfs and tmpfs mount to `/tmp`
- Confirmed `mktemp` works correctly in the mounted `/tmp` directory
- All tests pass

## Related

Bug: 58707